### PR TITLE
Add repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Attributes are depending on payload class.
 - `author_email`    - Author email (git)
 - `commit_url`      - Direct URL to view commit diff
 - `compare_url`     - Direct URL to view commits diff
+- `repository`       - Repository name
 
 ## Test Suite
 

--- a/lib/magnum/payload/base.rb
+++ b/lib/magnum/payload/base.rb
@@ -21,7 +21,8 @@ module Magnum
                   :committer_email, # Committer email address
                   :author_email,    # Commit author email address
                   :commit_url,      # Url to view commit diff
-                  :compare_url      # URL to view multiple commits diff
+                  :compare_url,      # URL to view multiple commits diff
+				  :repository          # Repository
 
       def initialize(payload)
         set_defaults
@@ -42,7 +43,8 @@ module Magnum
           "committer"   => committer,
           "message"     => message,
           "commit_url"  => commit_url,
-          "compare_url" => compare_url
+          "compare_url" => compare_url,
+		  "repository" => repository
         }
       end
 

--- a/lib/magnum/payload/github.rb
+++ b/lib/magnum/payload/github.rb
@@ -16,6 +16,7 @@ module Magnum
       @branch          = data.ref.gsub("refs/heads/", "")
       @commit_url      = last_commit.url
       @compare_url     = data.compare
+	  @repository       = data.repository.name
     end
 
     def skip_payload?

--- a/spec/payload/base_spec.rb
+++ b/spec/payload/base_spec.rb
@@ -93,7 +93,8 @@ describe Magnum::Payload::Base do
         "committer",
         "message",
         "commit_url",
-        "compare_url"
+        "compare_url",
+		"repository"
       ]
     end
   end

--- a/spec/payload/github_spec.rb
+++ b/spec/payload/github_spec.rb
@@ -41,6 +41,10 @@ describe Magnum::Payload::Github do
       expect(payload.compare_url).to eq "https://github.com/sosedoff/lxc-ruby/compare/0e46f019e391...9d227f327e72"
     end
 
+    it "sets commit repository" do
+      expect(payload.repository).to eq "lxc-ruby"
+    end
+	
     context "when push is forced" do
       let(:data) { fixture "github/forced.json" }
 


### PR DESCRIPTION
Hi there,

I'm using the same webhook for multiples repos and I need the repository name to know which jenkins jobs to trigger.

Feel free to ignore my PR if you feel like it's not needed in your code.

Cheers,
